### PR TITLE
4Kp60 is disabled, not 4K in general

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1038,7 +1038,7 @@ do_pi4video() {
       V3*)
         sed $CONFIG -i -e "s/^hdmi_enable_4kp60=/#hdmi_enable_4kp60=/"
         sed $CONFIG -i -e "s/^enable_tvout=/#enable_tvout=/"
-        STATUS="4K and analog disabled"
+        STATUS="4Kp60 and analog TV disabled"
         OPT=0
         ;;
       *)


### PR DESCRIPTION
Minor point but we've had at least one retropie user that thought they could use this option to disable 4K modes, so just removing all possible ambiguity :)